### PR TITLE
Fix unresolved symbols permanent_string, temporary_string

### DIFF
--- a/src/item_impl.f90
+++ b/src/item_impl.f90
@@ -4,6 +4,7 @@
 module impl_item__
   use fde_item
   use fde_typeinfo
+  use fde_basestring, only: temporary_string
   use fde_string
   use fde_ref
   use fde_basetypes

--- a/src/string.f90_tpp
+++ b/src/string.f90_tpp
@@ -6,7 +6,7 @@ module fde_string
   use fde_ref
   use fde_memoryref
   use fde_basestring, only: BaseString_t, basestring_len_ref, &
-                            attribute_permanent, attribute_volatile, permanent_string, temporary_string
+                            attribute_permanent, attribute_volatile
   use fde_ostream
   implicit none
   private
@@ -35,7 +35,6 @@ module fde_string
   public :: char
   public :: delete
   public :: set_attribute, attribute_permanent, attribute_volatile
-  public :: permanent_string, temporary_string
   public :: basestring_memoryref_c
 
   public :: lower, to_lower


### PR DESCRIPTION
Both variables are imported from fde_basestring into fde_string and have public visibility. Their symbols are however not exported explicitly, which seems to be confusing for "some recent and of course very good compilers" ....

By just knowing the compiled mod files, the compiler seems to assume that those variables can be referenced, which is not true here and might lead to unresolved external symbol linker errors. Even if they are not used, it seems to depend on the compiler's ability of optimizing them out, which seems to produce strange behavior that release configurations will link correctly but debug don't.

Fix is to hide those variables from public module fde_string. Alternatively the symbols could be marked for exportation. Other variables may be affected too but have been inconspicuous until now.

What do you think?