### PR TITLE
Export temporary_string and permanent_string

### DIFF
--- a/src/basestring.f90
+++ b/src/basestring.f90
@@ -1,4 +1,5 @@
 
+#include "fde/itfUtil.fpp"
 #include "fde/ref_status.fpp"
 
 module fde_basestring
@@ -13,7 +14,9 @@ module fde_basestring
 
   ! parameter definitions
 
+  !_SYM_EXPORT(temporary_string)
   type(BaseString_t), parameter :: temporary_string    = BaseString_t( null(), 0, _ref_WeakLent )
+  !_SYM_EXPORT(permanent_string)
   type(BaseString_t), parameter :: permanent_string    = BaseString_t( null(), 0, _ref_HardLent )
   integer(kind=1),    parameter :: attribute_volatile  = 0
   integer(kind=1),    parameter :: attribute_permanent = 1


### PR DESCRIPTION
Solution 2 described in #3
This will explicitly export the respective symbols and works for Intel 19 Fortran compiler.
 